### PR TITLE
Resolve Pydantic forward references for Polymarket models

### DIFF
--- a/research/polymarket-analyst/objects.py
+++ b/research/polymarket-analyst/objects.py
@@ -93,7 +93,6 @@ class PolymarketEvent(BaseModel):
     liquidityClob: Optional[float] = None
     _sync: Optional[bool] = None
     commentCount: Optional[int] = None
-    # markets: list[str, 'Market'] # forward reference Market defined below - TODO: double check this works as intended
     markets: Optional[list[Market]] = None
     tags: Optional[list[Tag]] = None
     cyom: Optional[bool] = None
@@ -226,3 +225,7 @@ class Article(BaseModel):
     urlToImage: Optional[str]
     publishedAt: Optional[str]
     content: Optional[str]
+
+
+PolymarketEvent.model_rebuild()
+Market.model_rebuild()


### PR DESCRIPTION
The task was to verify if the Pydantic forward reference `list[Market]` works as intended within the `PolymarketEvent` model. I have implemented the recommended best practice for Pydantic V2 by adding explicit `model_rebuild()` calls for the affected models at the end of the file. This ensures that the circular dependency between `PolymarketEvent` and `Market` is correctly resolved by Pydantic's validation and serialization engine.

Changes:
- Removed `# markets: list[str, 'Market'] # forward reference Market defined below - TODO: double check this works as intended`
- Added `PolymarketEvent.model_rebuild()`
- Added `Market.model_rebuild()`
- Removed temporary verification scripts and cleaned up the environment.

---
*PR created automatically by Jules for task [7896215172280193549](https://jules.google.com/task/7896215172280193549) started by @oyi77*