### PR TITLE
⚡ Replace synchronous sleep with asyncio.sleep in providers

### DIFF
--- a/content/content-generator/scripts/providers/byteplus.py
+++ b/content/content-generator/scripts/providers/byteplus.py
@@ -10,6 +10,7 @@ API Endpoints:
 Base URL: https://ark.ap-southeast.bytepluses.com/api/v3
 """
 
+import asyncio
 import json
 import os
 import ssl
@@ -122,7 +123,7 @@ class BytePlusProvider(AIProvider):
             raise ValueError(f"No task_id returned: {result}")
         return task_id
 
-    def _poll_task(self, task_id: str, timeout: int = 300, interval: int = 5) -> dict:
+    async def _poll_task(self, task_id: str, timeout: int = 300, interval: int = 5) -> dict:
         """Poll task until completed or timeout (seconds). Returns task result."""
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -135,7 +136,7 @@ class BytePlusProvider(AIProvider):
                 error = result.get("error", {})
                 raise RuntimeError(f"Task {status}: {error.get('message', 'Unknown error')} (code: {error.get('code', 'N/A')})")
 
-            time.sleep(interval)
+            await asyncio.sleep(interval)
 
         raise TimeoutError(f"Task {task_id} timed out after {timeout}s")
 
@@ -183,7 +184,7 @@ class BytePlusProvider(AIProvider):
 
         try:
             task_id = self._create_task(model, content, **kwargs)
-            task_result = self._poll_task(task_id, timeout=poll_timeout)
+            task_result = await self._poll_task(task_id, timeout=poll_timeout)
 
             task_content = task_result.get("content", {})
             video_url = task_content.get("video_url", "")

--- a/content/content-generator/scripts/providers/replicate.py
+++ b/content/content-generator/scripts/providers/replicate.py
@@ -4,6 +4,7 @@ This module provides the ReplicateProvider class for generating images
 using Replicate's API with Flux and Stable Diffusion 3.5 models.
 """
 
+import asyncio
 import json
 import os
 import ssl
@@ -211,7 +212,7 @@ class ReplicateProvider(AIProvider):
         ) as response:
             return json.loads(response.read().decode("utf-8"))
 
-    def _wait_for_completion(
+    async def _wait_for_completion(
         self,
         prediction_id: str,
         timeout: int = 300,
@@ -232,8 +233,6 @@ class ReplicateProvider(AIProvider):
             urllib.error.HTTPError: On HTTP errors
             urllib.error.URLError: On network errors
         """
-        import time
-
         elapsed = 0
         while elapsed < timeout:
             prediction = self._get_prediction(prediction_id)
@@ -248,7 +247,7 @@ class ReplicateProvider(AIProvider):
             elif status == "canceled":
                 raise Exception("Prediction was canceled")
 
-            time.sleep(poll_interval)
+            await asyncio.sleep(poll_interval)
             elapsed += poll_interval
 
         raise TimeoutError(f"Prediction timed out after {timeout} seconds")
@@ -385,7 +384,7 @@ class ReplicateProvider(AIProvider):
                 output = prediction.get("output", [])
             else:
                 # Wait for the prediction to complete
-                completed_prediction = self._wait_for_completion(
+                completed_prediction = await self._wait_for_completion(
                     prediction_id, timeout=timeout
                 )
                 output = completed_prediction.get("output", [])

--- a/content/content-generator/scripts/providers/vastai.py
+++ b/content/content-generator/scripts/providers/vastai.py
@@ -230,7 +230,7 @@ class VastAIProvider(AIProvider):
         except Exception:
             return "serverless", str(result)
 
-    def _poll_comfyui_history(self, worker_url: str, prompt_id: str) -> dict:
+    async def _poll_comfyui_history(self, worker_url: str, prompt_id: str) -> dict:
         deadline = time.time() + self.poll_timeout
         while time.time() < deadline:
             if worker_url == "serverless":
@@ -243,7 +243,7 @@ class VastAIProvider(AIProvider):
                     return history[prompt_id]
             except Exception:
                 pass
-            time.sleep(self.poll_interval)
+            await asyncio.sleep(self.poll_interval)
         raise TimeoutError(
             f"Polling timed out after {self.poll_timeout}s for prompt {prompt_id}"
         )
@@ -311,7 +311,7 @@ class VastAIProvider(AIProvider):
             worker_url, prompt_id = self._execute_via_vast_serverless(
                 comfyui_payload, cost=cost
             )
-            history = self._poll_comfyui_history(worker_url, prompt_id)
+            history = await self._poll_comfyui_history(worker_url, prompt_id)
             output = self._extract_video_from_history(history)
             if not output:
                 return GenerationResult(


### PR DESCRIPTION
💡 **What:** Replaced blocking `time.sleep` with non-blocking `await asyncio.sleep` in `ReplicateProvider`, `VastAIProvider`, and `BytePlusProvider`.
🎯 **Why:** These providers were using synchronous sleep within an asynchronous context (`async def generate`), which blocks the entire event loop and prevents concurrent operations during the polling phase.
📊 **Measured Improvement:** Verified using a reproduction script that `ReplicateProvider` no longer blocks the event loop during its polling phase. Before the fix, other concurrent tasks were completely stalled for the duration of the sleep (2 seconds per poll). After the fix, concurrent tasks are able to execute normally during the wait interval.

---
*PR created automatically by Jules for task [11835619258515970591](https://jules.google.com/task/11835619258515970591) started by @oyi77*