### PR TITLE
⚡ Bolt: Optimize cache eviction queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - [Optimize Cache Eviction]
+**Learning:** Found an N+1 query vulnerability in an SQLite-based cache class where enforcing maximum size during insert caused multiple serial SELECT and DELETE operations in a tight `while` loop. The previous query `ORDER BY created_at ASC LIMIT 1` also lacked an index, causing a full table scan repeatedly.
+**Action:** Replaced the loop with a single query of all records ordered by an indexed `created_at` using a server-side cursor iteration, locally aggregated keys to delete, and used `executemany` for batched deletion to improve query counts and memory usage without causing full table loading via `fetchall()`.

--- a/content/content-generator/scripts/cache.py
+++ b/content/content-generator/scripts/cache.py
@@ -52,6 +52,9 @@ class Cache:
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_hash ON cache(hash)
             """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_created_at ON cache(created_at)
+            """)
             conn.commit()
 
     def _get_connection(self) -> sqlite3.Connection:
@@ -195,19 +198,22 @@ class Cache:
 
             if total_size > max_bytes:
                 # Remove oldest entries until under limit
-                while total_size > max_bytes:
-                    cursor = conn.execute(
-                        """
-                        SELECT key, size FROM cache
-                        ORDER BY created_at ASC LIMIT 1
-                        """
-                    )
-                    row = cursor.fetchone()
-                    if not row:
-                        break
+                cursor = conn.execute(
+                    """
+                    SELECT key, size FROM cache
+                    ORDER BY created_at ASC
+                    """
+                )
 
-                    conn.execute("DELETE FROM cache WHERE key = ?", (row["key"],))
+                keys_to_delete = []
+                for row in cursor:
+                    if total_size <= max_bytes:
+                        break
+                    keys_to_delete.append((row["key"],))
                     total_size -= row["size"]
+
+                if keys_to_delete:
+                    conn.executemany("DELETE FROM cache WHERE key = ?", keys_to_delete)
                     conn.commit()
 
     def clear(self) -> int:

--- a/content/content-generator/scripts/test_cache.py
+++ b/content/content-generator/scripts/test_cache.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import time
+
+# Adjust path to find the cache module
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cache import Cache
+
+def test_cache_eviction():
+    test_db_path = ".cache/test_cache.db"
+    if os.path.exists(test_db_path):
+        os.remove(test_db_path)
+
+    # Very small cache size, e.g. 1 MB, but let's test logic explicitly with bytes size
+    # By default, max_size_mb is in MB.
+    # Let's insert large string values.
+
+    cache = Cache(db_path=test_db_path, max_size_mb=1)
+
+    # 1 MB is 1048576 bytes.
+    # We will insert values of size roughly 400KB
+    large_val1 = "A" * 400000
+    large_val2 = "B" * 400000
+    large_val3 = "C" * 400000
+    large_val4 = "D" * 400000
+
+    print("Setting key1")
+    cache.set("key1", large_val1)
+    time.sleep(0.1) # ensure order of created_at
+
+    print("Setting key2")
+    cache.set("key2", large_val2)
+    time.sleep(0.1)
+
+    print("Setting key3")
+    cache.set("key3", large_val3)
+    time.sleep(0.1)
+
+    print("Setting key4 (should trigger eviction)")
+    cache.set("key4", large_val4)
+
+    stats = cache.get_stats()
+    print("Cache Stats:", stats)
+
+    # key1 should have been evicted
+    assert cache.get("key1") is None, "key1 should be evicted"
+
+    # The cache should still contain the most recent keys that fit in limit
+    print("Cache eviction works!")
+
+    # Clean up test artifact
+    if os.path.exists(test_db_path):
+        os.remove(test_db_path)
+
+if __name__ == "__main__":
+    test_cache_eviction()


### PR DESCRIPTION
💡 What: Replaced the N+1 `while` loop implementation of `Cache._enforce_size_limit` with a single server-side cursor iteration and `executemany` batched deletion. Added an index on the `created_at` column.
🎯 Why: Enforcing cache size previously required N repeated full-table scans to find and remove the oldest records one by one, resulting in significant I/O and query parsing overhead.
📊 Impact: Reduces N+1 queries during size enforcement to just two queries total (one indexed SELECT and one batched DELETE), scaling O(1) in DB roundtrips instead of O(K) where K is the number of evicted items.
🔬 Measurement: Run `pytest` and/or the newly added `test_cache.py` script. The unit test performs rapid inserts to cross the eviction threshold and completes without errors.

---
*PR created automatically by Jules for task [841307683188847625](https://jules.google.com/task/841307683188847625) started by @oyi77*