### PR TITLE
⚡ Bolt: [performance improvement] Aggregate gallery stats in a single SQL query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - [Optimize Cache Eviction]
 **Learning:** Found an N+1 query vulnerability in an SQLite-based cache class where enforcing maximum size during insert caused multiple serial SELECT and DELETE operations in a tight `while` loop. The previous query `ORDER BY created_at ASC LIMIT 1` also lacked an index, causing a full table scan repeatedly.
 **Action:** Replaced the loop with a single query of all records ordered by an indexed `created_at` using a server-side cursor iteration, locally aggregated keys to delete, and used `executemany` for batched deletion to improve query counts and memory usage without causing full table loading via `fetchall()`.
+## 2024-05-15 - [Combine Aggregation Queries]
+**Learning:** Found a performance bottleneck in `gallery.py` where fetching basic statistics required 4 separate synchronous, sequential SQL queries using `COUNT` and `SUM` against the same table. This caused multiple redundant table/index scans.
+**Action:** Replaced the 4 queries with a single query using conditional aggregation (`SUM(CASE WHEN...)`) which reduced the database operations by 60% while maintaining the exact same functional output and logic. Remember to access returned result with integer indices (e.g. `row[0]`) instead of dictionary string keys when working with tuple returns in standard sqlite3 cursor execute.

--- a/content/content-generator/scripts/gallery.py
+++ b/content/content-generator/scripts/gallery.py
@@ -129,10 +129,21 @@ def get_stats(chat_id: str = None) -> dict:
     """Get gallery statistics"""
     where = f"WHERE chat_id = '{chat_id}'" if chat_id else ""
     with _conn() as conn:
-        total     = conn.execute(f"SELECT COUNT(*) FROM results {where}").fetchone()[0]
-        images    = conn.execute(f"SELECT COUNT(*) FROM results {where} {'AND' if where else 'WHERE'} type='image'").fetchone()[0] if total else 0
-        videos    = conn.execute(f"SELECT COUNT(*) FROM results {where} {'AND' if where else 'WHERE'} type='video'").fetchone()[0] if total else 0
-        total_cost = conn.execute(f"SELECT SUM(cost_usd) FROM results {where}").fetchone()[0] or 0
+        # ⚡ Bolt: Combined 4 aggregation queries into 1 to reduce redundant DB table scans and improve performance (~60% fewer queries).
+        row = conn.execute(f"""
+            SELECT
+                COUNT(*),
+                SUM(CASE WHEN type='image' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN type='video' THEN 1 ELSE 0 END),
+                SUM(cost_usd)
+            FROM results {where}
+        """).fetchone()
+
+        total = row[0] if row and row[0] else 0
+        images = row[1] if row and row[1] else 0
+        videos = row[2] if row and row[2] else 0
+        total_cost = row[3] if row and row[3] else 0
+
         top_style = conn.execute(f"SELECT style, COUNT(*) as c FROM results {where} GROUP BY style ORDER BY c DESC LIMIT 1").fetchone()
     return {
         "total": total,


### PR DESCRIPTION
💡 **What**: Combined 4 separate count/sum SQL queries into a single query using `SUM(CASE WHEN...)` in the `get_stats` method within `content/content-generator/scripts/gallery.py`. Also added the learning to my Bolt journal.

🎯 **Why**: To eliminate multiple redundant database index/table scans when calculating gallery statistics. Previously, determining total results, image count, video count, and total cost individually required 4 synchronous passes over the data. 

📊 **Impact**: Reduces database trips by 60% (from 5 to 2 queries per `get_stats` call), speeding up dashboard and bot message generation without changing functionality.

🔬 **Measurement**: Observe the query count per `get_stats` invocation in SQLite trace, verifying it is reduced. You can also measure the execution time of `get_stats()` before and after to observe the reduced latency.

---
*PR created automatically by Jules for task [2053178871070383526](https://jules.google.com/task/2053178871070383526) started by @oyi77*