### PR TITLE
⚡ Bolt: [performance improvement] Optimize episodic memory archival N+1 query

### DIFF
--- a/core/memory-system/scripts/episodic_memory.py
+++ b/core/memory-system/scripts/episodic_memory.py
@@ -324,8 +324,9 @@ class EpisodicMemory:
                     "SELECT id FROM episodes WHERE archived=0 ORDER BY importance ASC, timestamp ASC LIMIT ?",
                     (over,),
                 ).fetchall()
-                for (eid,) in rows:
-                    conn.execute("UPDATE episodes SET archived=1 WHERE id=?", (eid,))
+                # ⚡ Bolt Optimization: Batch N+1 UPDATE queries into a single executemany call
+                if rows:
+                    conn.executemany("UPDATE episodes SET archived=1 WHERE id=?", rows)
 
     def rebuild_index(self) -> None:
         self._rebuild_hnsw_from_db()


### PR DESCRIPTION
💡 **What**:
Replaced the `for` loop executing individual `UPDATE` statements in `_maybe_archive_old()` with a single `conn.executemany()` call.

🎯 **Why**:
When the episodic memory exceeds its maximum item count (`EPISODIC_MAX_ITEMS`), it triggers an archival process. Previously, this process fired a separate database query for each item being archived (an N+1 query problem). This is highly inefficient in SQLite, leading to unnecessary round-trips and potential lock contention.

📊 **Impact**:
Reduces database round-trips for the archive operation from O(N) to O(1), making bulk archival significantly faster and more resource-efficient.

🔬 **Measurement**:
Verified that the logic maintains exactly the same functionality through the existing `test_memory.py` test suite, which continues to pass completely. No architectural regressions introduced.

---
*PR created automatically by Jules for task [6558054839784951733](https://jules.google.com/task/6558054839784951733) started by @oyi77*