### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/core/memory-system/scripts/episodic_memory.py
+++ b/core/memory-system/scripts/episodic_memory.py
@@ -324,8 +324,8 @@ class EpisodicMemory:
                     "SELECT id FROM episodes WHERE archived=0 ORDER BY importance ASC, timestamp ASC LIMIT ?",
                     (over,),
                 ).fetchall()
-                for (eid,) in rows:
-                    conn.execute("UPDATE episodes SET archived=1 WHERE id=?", (eid,))
+                # ⚡ Bolt Optimization: Batch N+1 UPDATE queries into a single executemany call
+                conn.executemany("UPDATE episodes SET archived=1 WHERE id=?", rows)
 
     def rebuild_index(self) -> None:
         self._rebuild_hnsw_from_db()


### PR DESCRIPTION
💡 **What:** Replaced the loop executing an individual `UPDATE episodes SET archived=1 WHERE id=?` for each row with a single, batched `conn.executemany("UPDATE episodes SET archived=1 WHERE id=?", rows)` inside `_maybe_archive_old`.
🎯 **Why:** To eliminate N+1 query overhead during episodic memory archiving.
📊 **Impact:** Reduces database I/O and SQL compilation overhead drastically when archiving a large number of episodes.
🔬 **Measurement:** Confirmed via the memory system test suite that all episodic logic remains valid and functioning correctly.

---
*PR created automatically by Jules for task [7726530754549763916](https://jules.google.com/task/7726530754549763916) started by @oyi77*