### PR TITLE
⚡ Bolt: [performance improvement] Replace list with deque in BFS traversals for O(1) pops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2025-06-02 - SQLite N+1 Batched Updates via executemany
 **Learning:** In the memory system, looping over database SELECT results to run a single `UPDATE` query per row creates massive N+1 query bottlenecks and slows down `apply_decay` exponentially as the memory table grows.
 **Action:** When updating multiple database rows with dynamic variables, collect the parameter tuples in a list (`updates.append(...)`) and process them in a single batch operation using `sqlite3.Connection.executemany()` to minimize I/O overhead and database locking.
+## 2024-06-15 - BFS Traversal Optimization
+**Learning:** Python lists used as queues in `while queue:` loops and mutated with `.pop(0)` represent a hidden O(N) performance bottleneck in large graphs, causing quadratic time complexity for BFS traversals.
+**Action:** Always refactor lists used as queues in BFS/FIFO patterns to use `collections.deque` with `.popleft()` for guaranteed O(1) performance without sacrificing readability.

--- a/core/memory-system/scripts/memory_graph.py
+++ b/core/memory-system/scripts/memory_graph.py
@@ -19,6 +19,7 @@ import sqlite3
 import threading
 import time
 from typing import Dict, List, Optional, Set, Tuple
+from collections import deque
 
 from . import config
 
@@ -165,10 +166,11 @@ class MemoryGraph:
                 return []
 
             visited: Dict[str, Dict] = {}
-            queue: List[Tuple] = [(start_id, 0, [start_id])]
+            # ⚡ Bolt Optimization: Replace list with deque to eliminate O(N) pop(0) in BFS traversal
+            queue = deque([(start_id, 0, [start_id])])
 
             while queue:
-                node, hop, path = queue.pop(0)
+                node, hop, path = queue.popleft()
                 if hop >= max_hops:
                     continue
 

--- a/cybersecurity/implementing-soar-playbook-with-palo-alto-xsoar/scripts/process.py
+++ b/cybersecurity/implementing-soar-playbook-with-palo-alto-xsoar/scripts/process.py
@@ -10,6 +10,7 @@ import json
 import yaml
 from datetime import datetime
 from typing import Optional
+from collections import deque
 
 
 class PlaybookTask:
@@ -87,9 +88,10 @@ class XSOARPlaybook:
 
         # Check for orphaned tasks (not reachable from start)
         reachable = set()
-        queue = [self.start_task_id]
+        # ⚡ Bolt Optimization: Replace list with deque to eliminate O(N) pop(0) in BFS traversal
+        queue = deque([self.start_task_id])
         while queue:
-            current = queue.pop(0)
+            current = queue.popleft()
             if current in reachable:
                 continue
             reachable.add(current)


### PR DESCRIPTION
💡 What: Replaced standard Python lists with `collections.deque` for queues in BFS traversals across the codebase, specifically targeting `core/memory-system/scripts/memory_graph.py` and `cybersecurity/implementing-soar-playbook-with-palo-alto-xsoar/scripts/process.py`. Changed `queue.pop(0)` to `queue.popleft()`.

🎯 Why: Calling `.pop(0)` on a standard Python list is an O(N) operation because it requires shifting all subsequent elements in memory. In a Breadth-First Search over a large graph or playbook, this causes the queue processing to degrade into an O(N^2) operation, causing unnecessary CPU cycles.

📊 Impact: Reduces algorithmic complexity of node extraction from the queue from O(N) to O(1). This makes large multi-hop graph traversals scale linearly O(V + E) instead of quadratically, drastically improving CPU efficiency and preventing blocking the main thread during deep graph searches without sacrificing code readability.

🔬 Measurement: 
1. `cd core && ln -s memory-system memory_system`
2. `PYTHONPATH=$PWD/memory_system:$PWD python memory-system/scripts/test_memory.py`
3. Notice hybrid tests and multi-hop graph traversal metrics passing efficiently without errors.
4. `npm run test` continues to pass confirming zero breaking changes.

---
*PR created automatically by Jules for task [12029420376611463985](https://jules.google.com/task/12029420376611463985) started by @oyi77*