### PR TITLE
⚡ Bolt: [performance improvement] Optimize BFS queue in memory graph

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2025-06-02 - SQLite N+1 Batched Updates via executemany
 **Learning:** In the memory system, looping over database SELECT results to run a single `UPDATE` query per row creates massive N+1 query bottlenecks and slows down `apply_decay` exponentially as the memory table grows.
 **Action:** When updating multiple database rows with dynamic variables, collect the parameter tuples in a list (`updates.append(...)`) and process them in a single batch operation using `sqlite3.Connection.executemany()` to minimize I/O overhead and database locking.
+## 2025-06-16 - [Optimize Graph BFS Traversal]
+**Learning:** Found a severe O(N) performance bottleneck in the memory graph BFS algorithm (`memory_graph.py`) where a standard Python `List` was used as a queue with `queue.pop(0)`.
+**Action:** When implementing Breadth-First Search (BFS) traversals, always use `collections.deque` and `popleft()` instead of `list.pop(0)` to ensure O(1) dequeue performance.

--- a/core/memory-system/scripts/memory_graph.py
+++ b/core/memory-system/scripts/memory_graph.py
@@ -18,7 +18,8 @@ import logging
 import sqlite3
 import threading
 import time
-from typing import Dict, List, Optional, Set, Tuple
+from collections import deque
+from typing import Deque, Dict, List, Optional, Set, Tuple
 
 from . import config
 
@@ -165,10 +166,11 @@ class MemoryGraph:
                 return []
 
             visited: Dict[str, Dict] = {}
-            queue: List[Tuple] = [(start_id, 0, [start_id])]
+            # Using collections.deque instead of List to optimize pop(0) which is O(N)
+            queue: Deque[Tuple] = deque([(start_id, 0, [start_id])])
 
             while queue:
-                node, hop, path = queue.pop(0)
+                node, hop, path = queue.popleft()
                 if hop >= max_hops:
                     continue
 


### PR DESCRIPTION
💡 What: Replaced a standard Python `List` with `collections.deque` and used `popleft()` instead of `pop(0)` for the Breadth-First Search (BFS) algorithm in `core/memory-system/scripts/memory_graph.py`.

🎯 Why: Using `queue.pop(0)` on a standard Python list requires shifting all subsequent elements in memory, resulting in an O(N) operation per node visited. As the graph grows or the `max_hops` increases, this causes an overall O(N²) time complexity for the dequeue process.

📊 Impact: Reduces queue popping time complexity from O(N) to O(1), significantly speeding up multi-hop memory graph traversals, especially when traversing densely connected memories or deep hops.

🔬 Measurement: Run `cd core && PYTHONPATH=$PWD/memory_system:$PWD python memory-system/scripts/test_memory.py` and verify all tests pass and that graph traversal tests (Test 8) maintain low latency.

---
*PR created automatically by Jules for task [11380830108393320936](https://jules.google.com/task/11380830108393320936) started by @oyi77*