### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N) list.pop(0) with O(1) deque.popleft() in BFS queues

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2025-06-02 - SQLite N+1 Batched Updates via executemany
 **Learning:** In the memory system, looping over database SELECT results to run a single `UPDATE` query per row creates massive N+1 query bottlenecks and slows down `apply_decay` exponentially as the memory table grows.
 **Action:** When updating multiple database rows with dynamic variables, collect the parameter tuples in a list (`updates.append(...)`) and process them in a single batch operation using `sqlite3.Connection.executemany()` to minimize I/O overhead and database locking.
+## 2024-05-18 - Replacing O(N) list.pop(0) with O(1) deque.popleft() for BFS
+**Learning:** In Python, using `queue.pop(0)` on a standard list for Breadth-First Search (BFS) graph traversals is an O(N) operation because all subsequent elements must be shifted. In large graphs, this becomes a significant bottleneck. This anti-pattern was found in `memory_graph.py` and `process.py`.
+**Action:** Always import and use `collections.deque` and its `.popleft()` method for any queue-based structures, especially BFS algorithms, to guarantee O(1) time complexity per pop operation.

--- a/core/memory-system/scripts/memory_graph.py
+++ b/core/memory-system/scripts/memory_graph.py
@@ -18,6 +18,7 @@ import logging
 import sqlite3
 import threading
 import time
+from collections import deque
 from typing import Dict, List, Optional, Set, Tuple
 
 from . import config
@@ -165,10 +166,11 @@ class MemoryGraph:
                 return []
 
             visited: Dict[str, Dict] = {}
-            queue: List[Tuple] = [(start_id, 0, [start_id])]
+            # BOLT OPTIMIZATION: Replace list with deque for O(1) popleft() in BFS queue instead of O(N) list.pop(0)
+            queue: deque[Tuple] = deque([(start_id, 0, [start_id])])
 
             while queue:
-                node, hop, path = queue.pop(0)
+                node, hop, path = queue.popleft()
                 if hop >= max_hops:
                     continue
 

--- a/cybersecurity/implementing-soar-playbook-with-palo-alto-xsoar/scripts/process.py
+++ b/cybersecurity/implementing-soar-playbook-with-palo-alto-xsoar/scripts/process.py
@@ -10,6 +10,7 @@ import json
 import yaml
 from datetime import datetime
 from typing import Optional
+from collections import deque
 
 
 class PlaybookTask:
@@ -87,9 +88,10 @@ class XSOARPlaybook:
 
         # Check for orphaned tasks (not reachable from start)
         reachable = set()
-        queue = [self.start_task_id]
+        # BOLT OPTIMIZATION: Replace list with deque for O(1) popleft() in BFS queue instead of O(N) list.pop(0)
+        queue = deque([self.start_task_id])
         while queue:
-            current = queue.pop(0)
+            current = queue.popleft()
             if current in reachable:
                 continue
             reachable.add(current)


### PR DESCRIPTION
💡 **What:** Replaced the use of standard Python `list` structures as queues in Breadth-First Search (BFS) algorithms with `collections.deque`. Specifically changed `queue.pop(0)` to `queue.popleft()`.

🎯 **Why:** In Python, using `queue.pop(0)` on a standard list is an O(N) operation because it forces a memory shift of all subsequent elements. For graphs with a large number of nodes, this introduces an unnecessary and significant performance bottleneck. `collections.deque` is a double-ended queue implemented as a doubly linked list, which guarantees O(1) time complexity for appending and popping from either side.

📊 **Impact:** Reduces the time complexity of the node extraction operation in BFS traversals from O(N) to O(1). In large-scale graphs (e.g., within the memory graph traversing multi-hops or validating large playbooks), this will tangibly improve script execution time and CPU efficiency.

🔬 **Measurement:** Verify the changes by executing the tests for the respective modules:
- Run the memory system tests: `cd core && ln -s memory-system memory_system && pip install numpy hnswlib scikit-learn networkx && PYTHONPATH=$PWD/memory_system:$PWD python memory-system/scripts/test_memory.py && rm memory_system` (All 56 tests should pass and traversal logic verified).
- Run playbook validator tests: `pip install pyyaml && python3 cybersecurity/implementing-soar-playbook-with-palo-alto-xsoar/scripts/process.py` to ensure it parses without orphan task errors.

---
*PR created automatically by Jules for task [1325681544368620192](https://jules.google.com/task/1325681544368620192) started by @oyi77*