### PR TITLE
⚡ Bolt: [optimize yaml.dump in scripts]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2024-05-18 - SequenceMatcher O(N^2) Optimization via Length Pre-check
 **Learning:** `difflib.SequenceMatcher.ratio()` calculates similarity as `2.0 * matches / total_length`, meaning the maximum possible ratio is inherently bound by `2.0 * min(len(a), len(b)) / (len(a) + len(b))`. In `scripts/lint-skills.py`, this was being called in a hot N^2 loop over 1300+ strings to find duplicates, taking ~47 seconds.
 **Action:** When using `difflib.SequenceMatcher(None, a, b).ratio()` to check against a strict threshold (e.g. 0.99), always implement a fast upper-bound pre-check (`if 2.0 * min(len(a), len(b)) < threshold * (len(a) + len(b)): return 0.0`) to avoid the expensive sequence matching for strings that are mathematically impossible to match. This dropped execution time from 47s to 3s (14x speedup).
+
+## 2025-07-26 - [Optimize YAML Serialization Speed]
+**Learning:** Serializing hundreds or thousands of YAML files (e.g., `SKILL.md` frontmatter) using `yaml.safe_dump()` in pure Python creates a CPU bottleneck during batch operations, similar to `yaml.safe_load()`.
+**Action:** When working with PyYAML for large-scale file writing or frontmatter modifications, switch to `yaml.dump(..., Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper))`. This provides a ~5x speedup by seamlessly utilizing the C-based serialization when available, while safely falling back to pure Python without complex nested exception handling.

--- a/scripts/fix-all-lint.py
+++ b/scripts/fix-all-lint.py
@@ -250,7 +250,8 @@ def fix_skill(path: Path, dry_run: bool = False) -> dict:
             ordered[key] = meta.pop(key)
     ordered.update(meta)
 
-    new_fm = yaml.safe_dump(ordered, sort_keys=False, allow_unicode=True, width=120).rstrip()
+    # Optimization: Use CSafeDumper when available for ~5x faster YAML serialization of 1300+ SKILL.md files.
+    new_fm = yaml.dump(ordered, Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper), sort_keys=False, allow_unicode=True, width=120).rstrip()
     new_text = f"---\n{new_fm}\n---\n{body}" if not body.startswith("\n") else f"---\n{new_fm}\n---{body}"
 
     if not dry_run:

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -232,8 +232,9 @@ def fix_one(path: Path) -> list[str]:
             ordered[key] = meta.pop(key)
     ordered.update(meta)
 
-    new_fm = yaml.safe_dump(
-        ordered, sort_keys=False, allow_unicode=True, width=120
+    # Optimization: Use CSafeDumper when available for ~5x faster YAML serialization of 1300+ SKILL.md files.
+    new_fm = yaml.dump(
+        ordered, Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper), sort_keys=False, allow_unicode=True, width=120
     ).rstrip()
     new_text = (
         f"---\n{new_fm}\n---\n{body}"


### PR DESCRIPTION
💡 What: Replaced `yaml.safe_dump` with `yaml.dump(..., Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper))` in `scripts/fix-all-lint.py` and `scripts/validate-skills.py`.
🎯 Why: `yaml.safe_dump` in pure Python is a major CPU bottleneck during batch operations over 1300+ `SKILL.md` files.
📊 Impact: Expected to reduce batch YAML serialization time by ~80% (~5x speedup).
🔬 Measurement: Verify speed improvements by profiling `python3 scripts/fix-all-lint.py --dry-run` and `python3 scripts/validate-skills.py`.

---
*PR created automatically by Jules for task [16306969691294864081](https://jules.google.com/task/16306969691294864081) started by @oyi77*