### PR TITLE
⚡ Bolt: Optimize YAML serialization with CSafeDumper

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2024-05-18 - SequenceMatcher O(N^2) Optimization via Length Pre-check
 **Learning:** `difflib.SequenceMatcher.ratio()` calculates similarity as `2.0 * matches / total_length`, meaning the maximum possible ratio is inherently bound by `2.0 * min(len(a), len(b)) / (len(a) + len(b))`. In `scripts/lint-skills.py`, this was being called in a hot N^2 loop over 1300+ strings to find duplicates, taking ~47 seconds.
 **Action:** When using `difflib.SequenceMatcher(None, a, b).ratio()` to check against a strict threshold (e.g. 0.99), always implement a fast upper-bound pre-check (`if 2.0 * min(len(a), len(b)) < threshold * (len(a) + len(b)): return 0.0`) to avoid the expensive sequence matching for strings that are mathematically impossible to match. This dropped execution time from 47s to 3s (14x speedup).
+## 2025-02-28 - PyYAML C-extension usage for serialization
+**Learning:** Just like `yaml.safe_load()`, using `yaml.safe_dump()` in pure Python creates a massive CPU bottleneck during batch operations (like fixing hundreds of `SKILL.md` frontmatters).
+**Action:** When updating or serializing multiple YAML files, use `yaml.dump(..., Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper))` to dramatically improve performance by utilizing the PyYAML C-extension (`libyaml`) when available.

--- a/scripts/fix-all-lint.py
+++ b/scripts/fix-all-lint.py
@@ -250,7 +250,7 @@ def fix_skill(path: Path, dry_run: bool = False) -> dict:
             ordered[key] = meta.pop(key)
     ordered.update(meta)
 
-    new_fm = yaml.safe_dump(ordered, sort_keys=False, allow_unicode=True, width=120).rstrip()
+    new_fm = yaml.dump(ordered, sort_keys=False, allow_unicode=True, width=120, Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper)).rstrip()
     new_text = f"---\n{new_fm}\n---\n{body}" if not body.startswith("\n") else f"---\n{new_fm}\n---{body}"
 
     if not dry_run:

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -232,8 +232,8 @@ def fix_one(path: Path) -> list[str]:
             ordered[key] = meta.pop(key)
     ordered.update(meta)
 
-    new_fm = yaml.safe_dump(
-        ordered, sort_keys=False, allow_unicode=True, width=120
+    new_fm = yaml.dump(
+        ordered, sort_keys=False, allow_unicode=True, width=120, Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper)
     ).rstrip()
     new_text = (
         f"---\n{new_fm}\n---\n{body}"


### PR DESCRIPTION
💡 **What:** Replaced `yaml.safe_dump()` with `yaml.dump(..., Dumper=getattr(yaml, 'CSafeDumper', yaml.SafeDumper))` in the batch validation and linting scripts (`scripts/validate-skills.py` and `scripts/fix-all-lint.py`).

🎯 **Why:** `yaml.safe_dump()` uses pure Python, which creates a significant CPU bottleneck when serializing hundreds of YAML frontmatter blocks during batch operations (like `fix-all-lint.py`). Using `CSafeDumper` utilizes the PyYAML C-extension (`libyaml`), which operates significantly faster while maintaining identical security and formatting.

📊 **Impact:** Expected ~5x speedup in YAML serialization during batch processing of `SKILL.md` files.

🔬 **Measurement:** Verify the optimization by running `python3 scripts/validate-skills.py` and `python3 scripts/test-skills.py --quick`. The tests will pass with valid YAML, and performance can be measured on large batch operations.

---
*PR created automatically by Jules for task [11389963013204968779](https://jules.google.com/task/11389963013204968779) started by @oyi77*